### PR TITLE
update handleResponse function to output contextual error

### DIFF
--- a/codewarden.js
+++ b/codewarden.js
@@ -52,7 +52,7 @@ async function runCodeWarden() {
 
 
   } catch (error) {
-    core.setFailed('Unexpected Error: Code Warden encountered an issue ' + error.message);
+    handleError(null, error.message);
   }
 }
 
@@ -71,8 +71,12 @@ function handleResponse(response) {
   (statuses[status] || defaultAction)();
 }
 
-function handleError(responseBody = null, contextError = error.message) {
-  let codeWardenErrorMessage = "Unexpected Error: Code Warden encountered an issue"
+function handleError(responseBody = null, contextError = null) {
+  let codeWardenErrorMessage = '';
+  if (contextError != null) {
+    codeWardenErrorMessage = `Unexpected Error: Code Warden encountered an issue \n ${contextError}`;
+  }
+  
 
   if (responseBody) {
     responseErrorCode = responseBody.errorCode;

--- a/tests/codewarden.test.js
+++ b/tests/codewarden.test.js
@@ -90,10 +90,10 @@ describe('Test Code Warden GitHub Action', () => {
       expectedPayload,
       postConfig
     );
-
-    expect(core.info).toHaveBeenCalledWith('Code Warden workflow started'); 
-    expect(core.info).toHaveBeenCalledWith('Calling Code Warden Endpoint: http://codewarden-jira.com/rest/analyze/1.0/pr'); 
-    expect(core.info).toHaveBeenCalledWith('Pull Request Analyzed by Code Warden. Comment has been added to Pull Request');
+    
+    expect(core.info).toHaveBeenNthCalledWith(1, 'Code Warden workflow started');
+    expect(core.info).toHaveBeenNthCalledWith(2, 'Calling Code Warden Endpoint: http://codewarden-jira.com/rest/analyze/1.0/pr');
+    expect(core.info).toHaveBeenNthCalledWith(3, 'Pull Request analyzed. Comment has been added to Pull Request');
     expect(core.setFailed).not.toHaveBeenCalled();
     expect(process.exit).not.toHaveBeenCalled();
   });
@@ -144,7 +144,7 @@ describe('Test Code Warden GitHub Action', () => {
       postConfig
     );
     expect(core.info).toHaveBeenCalledWith('Code Warden workflow started'); 
-    expect(core.setFailed).toHaveBeenCalledWith('Unexpected Error: Code Warden encountered an issue');
+    expect(core.setFailed).toHaveBeenCalledWith('Unexpected Error: Code Warden encountered an issue \n Internal Server Error: Something went wrong on our side');
   });
   
   it('should handle failed analysis status 500 with error code', async () => {
@@ -303,7 +303,7 @@ describe('Test Code Warden GitHub Action', () => {
 
     await runCodeWarden();
     expect(core.info).toHaveBeenCalledWith('Code Warden workflow started'); 
-    expect(core.setFailed).toHaveBeenCalledWith('Unexpected Error: Code Warden encountered an issue Cannnot get key');
+    expect(core.setFailed).toHaveBeenCalledWith('Unexpected Error: Code Warden encountered an issue \n Cannnot get key');
 
   });
 });


### PR DESCRIPTION
Not sure if this will work within the flow since it uses some non-vanilla syntax. Wanted to add a little more context to errors. Did not write any tests. Wanted to make sure this was a direction we could/wanted to take before finishing it up.